### PR TITLE
Dev all job postings

### DIFF
--- a/controller/jobPostingPublicController.ts
+++ b/controller/jobPostingPublicController.ts
@@ -1,5 +1,7 @@
 import type { Request, Response } from "express";
 import { JobPostingService } from "../service/jobPostingService.js";
+import {isJobType, isPosition} from "../utils/validatorEnum.js";
+import type { JobType, Position } from "../utils/enums.js";
 
 export class JobPostingPublicController {
 
@@ -12,9 +14,20 @@ export class JobPostingPublicController {
 
     async get_all_job_postings(req: Request, res: Response){
         try{
-            const { keyword, category } = req.query as { keyword: string; category: string };
+            const { keyword, category, jobType } = req.query as { keyword: string; category: string; jobType: string };
 
-            const jobPostings = await this.JobPostingService.get_all_job_postings(keyword, category);
+            // Validate category
+            const positionEnum = category && isPosition(category) ? category : undefined;
+            if (category && !positionEnum) {
+                return res.status(400).json({ message: `Invalid category: ${category}` });
+            }
+
+            // Validate jobType
+            const jobTypeEnum = jobType && isJobType(jobType) ? jobType : undefined;
+            if (jobType && !jobTypeEnum) {
+                return res.status(400).json({ message: `Invalid jobType: ${jobType}` });
+            }
+            const jobPostings = await this.JobPostingService.get_all_job_postings(keyword, positionEnum, jobTypeEnum);
             res.json({ job_postings: jobPostings });
         }catch(error: unknown){
             console.error((error as Error).message);

--- a/controller/jobPostingPublicController.ts
+++ b/controller/jobPostingPublicController.ts
@@ -22,6 +22,20 @@ export class JobPostingPublicController {
         }
     }
 
+    async get_job_posting_by_id(req: Request, res: Response){
+        try{
+            const { id } = req.params;
+            const jobPosting = await this.JobPostingService.get_job_posting_by_id(Number(id));
+            if (!jobPosting) {
+                return res.status(404).json({ message: "Job posting not found" });
+            }
+            res.json({ job_posting: jobPosting });
+        }catch(error: unknown){
+            console.error((error as Error).message);
+            res.status(500).json({ message: (error as Error).message });
+        }
+    }
+
 
     
 

--- a/controller/jobPostingPublicController.ts
+++ b/controller/jobPostingPublicController.ts
@@ -1,7 +1,8 @@
 import type { Request, Response } from "express";
 import { JobPostingService } from "../service/jobPostingService.js";
 import {isJobType, isPosition} from "../utils/validatorEnum.js";
-import type { JobType, Position } from "../utils/enums.js";
+import { JobType, Position } from "../utils/enums.js";
+import { enumToDropdown } from "../utils/enumToDropdown.js";
 
 export class JobPostingPublicController {
 
@@ -11,6 +12,16 @@ export class JobPostingPublicController {
         this.JobPostingService = new JobPostingService();
     }
 
+    async get_all_job_categories(req: Request, res: Response) {
+        const categories = enumToDropdown(Position);
+        res.json({ categories });
+    }
+
+    async get_all_job_types(req: Request, res: Response) {
+        console.log("Getting all job types");
+        const jobTypes = enumToDropdown(JobType);
+        res.json({ jobTypes });
+    }
 
     async get_all_job_postings(req: Request, res: Response){
         try{

--- a/controller/jobPostingPublicController.ts
+++ b/controller/jobPostingPublicController.ts
@@ -1,0 +1,31 @@
+import type { Request, Response } from "express";
+import { JobPostingService } from "../service/jobPostingService.js";
+
+export class JobPostingPublicController {
+
+    private JobPostingService: JobPostingService;
+
+    constructor(){
+        this.JobPostingService = new JobPostingService();
+    }
+
+
+    async get_all_job_postings(req: Request, res: Response){
+        try{
+            const { keyword, category } = req.query as { keyword: string; category: string };
+
+            const jobPostings = await this.JobPostingService.get_all_job_postings(keyword, category);
+            res.json({ job_postings: jobPostings });
+        }catch(error: unknown){
+            console.error((error as Error).message);
+            res.status(500).json({ message: (error as Error).message });
+        }
+    }
+
+
+    
+
+    
+
+
+}

--- a/dtoModel/jobPostingDTO.ts
+++ b/dtoModel/jobPostingDTO.ts
@@ -1,0 +1,25 @@
+import type { jobPost } from "@prisma/client";
+
+export interface JobPostingFeedDTO {
+  id: number;
+  position: string;
+  description: string;
+  jobType: string;
+  available_position: number;
+  company_name: string;
+  company_profile_image: string | null;
+  company_location: string;
+  company_tel: string;
+  created_at: Date;
+  updated_at: Date;
+  posted_ago: string;
+}
+
+export interface companyInfoDTO {
+    user_id: number;
+    company_name: string;
+    location: string;
+    tel: string;
+}
+
+export type JobPostWithCompany = jobPost & { company: companyInfoDTO };

--- a/index.ts
+++ b/index.ts
@@ -13,6 +13,7 @@ import jwtMiddleware from "./middlewares/jwtMiddleware.js";
 import adminRouter from "./router/adminRoutes.js";
 import companyRouter from "./router/companyRoutes.js";
 import authorizeRole from "./middlewares/rolebasedMiddleware.js";
+import companyJobPostingRouter from "./router/jobPostingPublicRoutes.js";
 
 dotenv.config();
 const port = process.env.PORT || 8000;
@@ -29,6 +30,7 @@ app.use("/api/user", userRouter)
 app.use("/api/auth", authRouter);
 app.use("/api/admin", adminRouter);
 app.use("/api/company", authorizeRole("Company"), companyRouter);
+app.use("/api/job-postings", companyJobPostingRouter); // feed job postings
 
 
 app.get("/", (req, res) => {

--- a/repository/jobPostingRepository.ts
+++ b/repository/jobPostingRepository.ts
@@ -10,22 +10,8 @@ export class JobPostingPublicRepository {
         this.prisma = PrismaDB.getInstance();
     }
 
-    private normalizeEnum(val: string): JobType | undefined {
-        // normalize input: lowercase, remove spaces, underscores, etc.
-        const normalizedInput = val.toLowerCase().replace(/[\s_]/g, "");
 
-        for (const enumVal of Object.values(JobType)) {
-            const normalizedEnum = enumVal.toLowerCase().replace(/[\s_]/g, "");
-            if (normalizedEnum === normalizedInput) {
-            return enumVal as JobType;
-            }
-        }
-
-        return undefined;
-    }
-
-    async get_all_job_postings(keyword?: string, category?: string) {
-        const jobTypeEnum = keyword ? this.normalizeEnum(keyword) : undefined;
+    async get_all_job_postings(keyword?: string, category?: string, jobType?: string) {
         return this.prisma.jobPost.findMany({
             where: {
                 available_position: {
@@ -36,12 +22,13 @@ export class JobPostingPublicRepository {
                     { description: { contains: keyword, mode: "insensitive" } },
                     { company: { company_name: { contains: keyword, mode: "insensitive" } } },
                     { company: { location: { contains: keyword, mode: "insensitive" } } },
-                    ...(jobTypeEnum ? [{ jobType: jobTypeEnum }] : [])
                     
                     ],
                 }),
                 // category = exact match with Position enum
-                ...(category && { position: category as any })
+                // jobType = exact match with JobType enum
+                ...(category && { position: category as any }),
+                ...(jobType && { jobType: jobType as JobType })
                 
             },
             orderBy: {

--- a/repository/jobPostingRepository.ts
+++ b/repository/jobPostingRepository.ts
@@ -1,0 +1,64 @@
+import type { PrismaClient } from "@prisma/client";
+import { PrismaDB } from "../helper/prismaSingleton.js";
+import { JobType } from "../dtoModel/companyDTO.js";
+
+export class JobPostingPublicRepository {
+
+    private prisma: PrismaClient
+
+    constructor() {
+        this.prisma = PrismaDB.getInstance();
+    }
+
+    private normalizeEnum(val: string): JobType | undefined {
+        // normalize input: lowercase, remove spaces, underscores, etc.
+        const normalizedInput = val.toLowerCase().replace(/[\s_]/g, "");
+
+        for (const enumVal of Object.values(JobType)) {
+            const normalizedEnum = enumVal.toLowerCase().replace(/[\s_]/g, "");
+            if (normalizedEnum === normalizedInput) {
+            return enumVal as JobType;
+            }
+        }
+
+        return undefined;
+    }
+
+    async get_all_job_postings(keyword?: string, category?: string) {
+        const jobTypeEnum = keyword ? this.normalizeEnum(keyword) : undefined;
+        return this.prisma.jobPost.findMany({
+            where: {
+                available_position: {
+                    gt: 0 // only show job postings with available positions
+                },
+                ...(keyword && {
+                    OR: [
+                    { description: { contains: keyword, mode: "insensitive" } },
+                    { company: { company_name: { contains: keyword, mode: "insensitive" } } },
+                    { company: { location: { contains: keyword, mode: "insensitive" } } },
+                    ...(jobTypeEnum ? [{ jobType: jobTypeEnum }] : [])
+                    
+                    ],
+                }),
+                // category = exact match with Position enum
+                ...(category && { position: category as any })
+                
+            },
+            orderBy: {
+                updated_at: 'desc',
+            },
+            include: {
+                company: {
+                    select: {
+                    company_name: true,
+                    location: true,
+                    tel: true,
+                    user_id: true
+                    }
+                }
+            }
+        });
+    }
+
+
+}

--- a/repository/jobPostingRepository.ts
+++ b/repository/jobPostingRepository.ts
@@ -60,5 +60,20 @@ export class JobPostingPublicRepository {
         });
     }
 
+    async get_job_posting_by_id(id: number) {
+        return this.prisma.jobPost.findUnique({
+            where: { id },
+            include: {
+                company: {
+                    select: {
+                    company_name: true,
+                    location: true,
+                    tel: true,
+                    user_id: true
+                    }
+                }
+            }
+        });
+    }
 
 }

--- a/router/jobPostingPublicRoutes.ts
+++ b/router/jobPostingPublicRoutes.ts
@@ -5,9 +5,9 @@ import { JobPostingPublicController} from "../controller/jobPostingPublicControl
 const router = Router();
 const jobPostingPublicController = new JobPostingPublicController();
 
-// /api/job-postings?keyword=part time&category=Backend_Developer
+// /api/job-postings?keyword=Emily Company&category=Backend_Developer&jobType=PartTime
 router.get("/", (req, res) => {
-    // return all job postings
+    // return all job postings with optional filters: keyword, category, jobType
     jobPostingPublicController.get_all_job_postings(req, res);
 })
 

--- a/router/jobPostingPublicRoutes.ts
+++ b/router/jobPostingPublicRoutes.ts
@@ -1,0 +1,14 @@
+import { Router } from "express"
+import { JobPostingPublicController} from "../controller/jobPostingPublicController.js";
+
+
+const router = Router();
+const jobPostingPublicController = new JobPostingPublicController();
+
+// /api/job-postings?keyword=part time&category=Backend_Developer
+router.get("/", (req, res) => {
+    // return all job postings
+    jobPostingPublicController.get_all_job_postings(req, res);
+})
+
+export default router;

--- a/router/jobPostingPublicRoutes.ts
+++ b/router/jobPostingPublicRoutes.ts
@@ -11,6 +11,20 @@ router.get("/", (req, res) => {
     jobPostingPublicController.get_all_job_postings(req, res);
 })
 
+// /api/job-postings/category
+router.get("/category", (req, res) => {
+    // for dropdown
+    // return all job categories (Position enum values)
+    jobPostingPublicController.get_all_job_categories(req, res);
+})
+
+// /api/job-postings/job-type
+router.get("/job-type", (req, res) => {
+    // for dropdown
+    // return all job types (JobType enum values)
+    jobPostingPublicController.get_all_job_types(req, res);
+})
+
 // /api/job-postings/:id
 router.get("/:id", (req, res) => {
     // return job posting by id

--- a/router/jobPostingPublicRoutes.ts
+++ b/router/jobPostingPublicRoutes.ts
@@ -11,4 +11,10 @@ router.get("/", (req, res) => {
     jobPostingPublicController.get_all_job_postings(req, res);
 })
 
+// /api/job-postings/:id
+router.get("/:id", (req, res) => {
+    // return job posting by id
+    jobPostingPublicController.get_job_posting_by_id(req, res);
+})
+
 export default router;

--- a/service/jobPostingService.ts
+++ b/service/jobPostingService.ts
@@ -1,0 +1,44 @@
+import { JobPostingPublicRepository } from "../repository/jobPostingRepository.js";
+import { UserService } from "./userService.js";
+
+export class JobPostingService {
+
+    private jobPostingRepository: JobPostingPublicRepository;
+    private userService: UserService;
+
+    constructor() {
+        this.jobPostingRepository = new JobPostingPublicRepository()
+        this.userService = new UserService();
+    }
+
+    private postedAgo(created_at: Date) {
+        const days = Math.floor((Date.now() - new Date(created_at).getTime()) / 86400000);
+        if (days <= 0) return "today";
+        if (days === 1) return "1 day ago";
+        return `${days} days ago`;
+    }
+
+    async get_all_job_postings(keyword?: string, category?: string) {
+        const item = await this.jobPostingRepository.get_all_job_postings(keyword, category);
+        const jobPostings = await Promise.all(
+        item.map(async (job) => ({
+            id: job.id,
+            position: job.position,
+            description: job.description,
+            jobType: job.jobType,
+            available_position: job.available_position,
+            company_id: job.company.user_id,
+            company_name: job.company.company_name,
+            company_profile_image: await this.userService.get_profile_image(job.company.user_id),
+            company_location: job.company.location,
+            company_tel: job.company.tel,
+            created_at: job.created_at,
+            updated_at: job.updated_at,
+            posted_ago: this.postedAgo(job.created_at) // use dto or model?
+        }))
+        );
+
+        return jobPostings;
+        
+    }
+}

--- a/service/jobPostingService.ts
+++ b/service/jobPostingService.ts
@@ -37,8 +37,8 @@ export class JobPostingService {
         };
     }
 
-    async get_all_job_postings(keyword?: string, category?: string): Promise<JobPostingFeedDTO[]> {
-        const items = await this.jobPostingRepository.get_all_job_postings(keyword, category);
+    async get_all_job_postings(keyword?: string, category?: string, jobType?: string): Promise<JobPostingFeedDTO[]> {
+        const items = await this.jobPostingRepository.get_all_job_postings(keyword, category, jobType);
         return Promise.all(items.map((job) => this.toFeedDTO(job)));
     }
 

--- a/service/userService.ts
+++ b/service/userService.ts
@@ -147,7 +147,7 @@ export class UserService {
     async get_profile_image(user_id: number){
         const user = await this.userRepository.get_user_by_id(user_id);
         if(!user.profile_image){
-            throw new Error("No profile image found");
+            return null;
         }
         const imageUrl = await this.s3Service.getImageUrl(user.profile_image);
         return imageUrl;

--- a/utils/enumToDropdown.ts
+++ b/utils/enumToDropdown.ts
@@ -1,0 +1,6 @@
+export function enumToDropdown<T extends { [key: string]: string }>(e: T) {
+  return Object.values(e).map(v => ({
+    value: v,
+    label: v.replace(/_/g, " ").replace(/([a-z])([A-Z])/g, "$1 $2")
+  }));
+}

--- a/utils/validatorEnum.ts
+++ b/utils/validatorEnum.ts
@@ -1,0 +1,9 @@
+import {JobType, Position} from "./enums.js";
+
+export function isJobType(val: any): val is JobType {
+  return Object.values(JobType).includes(val as JobType);
+}
+
+export function isPosition(val: any): val is Position {
+  return Object.values(Position).includes(val as Position);
+}


### PR DESCRIPTION
##  Description
- Return all job postings for public feed via `http://localhost:8000/api/job-postings`
<img width="1078" height="658" alt="Screenshot 2568-10-02 at 23 26 26" src="https://github.com/user-attachments/assets/b6783c12-d8a0-4463-bde5-9e3173362ce8" />

- Return job posting by id via `http://localhost:8000/api/job-postings/:id`
- Return Dropdown values for job category via  `http://localhost:8000/api/job-postings/category`
- Return Dropdown values for job type via  `http://localhost:8000/api/job-postings/job-type`

## Related Issue
[Return every job posting for feed API](https://github.com/ku-company/ku-company-backend/issues/44)

## Type of Change
- New feature (non-breaking change that adds functionality)

## Changes Made
- Job posting can be filter with query parameters (`keyword`, `category`, `jobType`). Btw, category and jobType should be value from dropdown.
- `keyword` is case insensitive.