### PR TITLE
Dev fix prof email

### DIFF
--- a/repository/userRepository.ts
+++ b/repository/userRepository.ts
@@ -44,7 +44,7 @@ export class UserRepository {
             throw new Error("Email must be a valid ku.th email address");
         }
         else if(input.role === Role.Professor){
-            if(input.email.endsWith("@ku.th") && input.email.startsWith("feng")){
+            if(input.email.endsWith("@ku.th") || input.email.endsWith("@ku.ac.th")){
                 return await this.prisma.user.create({
                     data: {
                         first_name: input.first_name,
@@ -59,7 +59,8 @@ export class UserRepository {
                     }
                 })
             }
-            throw new Error("Email must be a valid ku.th email address");
+            console.log("Invalid email for professor:", input.email);
+            throw new Error("Email must be a valid ku.th or ku.ac.th email address");
         }
         else if(input.role === Role.Admin){
             return await this.prisma.user.create({
@@ -212,8 +213,8 @@ export class UserRepository {
                 throw new Error("Email must be a valid ku.th email address");
             }
         } else if (new_role === Role.Professor) {
-            if (!(email.endsWith("@ku.th") && email.startsWith("feng"))) {
-            throw new Error("Email must be a valid ku.th email address for professors");
+            if (!(email.endsWith("@ku.th") && !email.endsWith("@ku.ac.th"))) {
+            throw new Error("Email must be a valid ku.th or ku.ac.th email address for professors");
             }
         }
         


### PR DESCRIPTION
##  Description
- Professor can sign up with their email that ends with either @ku.ac.th or @ku.th
<img width="524" height="81" alt="Screenshot 2568-10-25 at 16 13 51" src="https://github.com/user-attachments/assets/f9156f61-8435-44e3-bc46-4de93ff0dd72" />

## Related Issue

## Type of Change
<!-- Please delete options that are not relevant. -->
-  Bug fix (non-breaking change that fixes an issue)

## Changes Made
- allow prof email to end with @ku.ac.th and @ku.th
- remove the validation that prof email should start with feng