### PR TITLE
professor can create profile and get without being verified.

### DIFF
--- a/router/professorRoutes.ts
+++ b/router/professorRoutes.ts
@@ -6,18 +6,21 @@ import { ProfessorController } from "../controller/professorController.js";
 
 const router = Router();
 const professorController = new ProfessorController();
-router.use(verifiedMiddleware);
 router.use(authorizeRole("Professor", "Admin"));
 
 
 // === Professor Profile Routes ===
 router.get("/my-profile", async (req: Request, res: Response) =>{
+    // does not require verified middleware
     professorController.get_professor_profile(req, res)
 })
 
 router.post("/my-profile", async (req , res) =>{
+    // does not require verified middleware
     professorController.create_profile(req, res)
 })
+
+router.use(verifiedMiddleware);
 
 router.patch("/my-profile", async (req , res) => {
     professorController.edit_profile(req, res)
@@ -27,6 +30,8 @@ router.delete("/my-profile", async (req , res) => {
     professorController.delete_profile(req,res)
 })
 
+
+// === Professor Comment Routes ===
 router.post("/comment/:id", async (req , res) =>{
     professorController.add_comment_to_company(req, res)
 })
@@ -68,6 +73,7 @@ router.post("/opinions", async (req, res) => {
 router.get("/opinions/all", async (req, res) => {
     professorController.get_all_opinions(req, res)
 })
+
 
 // === General Posting Routes === (opinion, announcement, repost)
 router.get("/posts/all", async (req , res) =>{


### PR DESCRIPTION
##  Description
- get professor profile (unverified but role professor) `http://localhost:8000/api/professor/my-profile`
<img width="913" height="676" alt="Screenshot 2568-10-27 at 12 19 14" src="https://github.com/user-attachments/assets/52d64273-216d-4bf8-88bc-56c68c03fa69" />


- post professor profile (unverified but role professor) `http://localhost:8000/api/professor/my-profile`
<img width="887" height="676" alt="Screenshot 2568-10-27 at 12 20 45" src="https://github.com/user-attachments/assets/206ff9e5-b4a0-43fc-8683-4d306e38ad92" />
required body:
{ "department": "computer", "faculty": "engineering" }
(both fields are text field)
<img width="916" height="374" alt="Screenshot 2568-10-27 at 12 21 51" src="https://github.com/user-attachments/assets/ec1fca21-adaa-4c8e-86a4-6f6ca4fd1659" />

## Related Issue

## Type of Change
- Bug fix (non-breaking change that fixes an issue)

## Changes Made
- professorRouter changes to not require professor being verified to create/retrieve their profile.