### PR TITLE
admin can change user status to pending

### DIFF
--- a/controller/adminController.ts
+++ b/controller/adminController.ts
@@ -104,4 +104,18 @@ export class AdminController{
             })
         }
     }
+
+    async pending_user(req: any, res: any){
+        try{
+            const result = await this.admminService.pending_user(req.params.id)
+            res.status(200).json({
+                message: "User status changed to pending successfully",
+                data: result
+            })
+        }catch(error: any){
+            res.status(400).json({
+                message: error.message
+            })
+        }
+    }
 }

--- a/repository/adminRepository.ts
+++ b/repository/adminRepository.ts
@@ -182,4 +182,19 @@ export class AdminRepository{
         })
         return user
     }
+
+    async pending_user(id: number){
+        const user_id = await this.find_user(id)
+        const updated_user = await this.prisma.user.update({
+            where: {
+                id: user_id
+            },
+            data: {
+                verified: false,
+                status: "Pending",
+                updated_at: new Date()
+            }
+        })
+        return updated_user
+    }
 }

--- a/router/adminRoutes.ts
+++ b/router/adminRoutes.ts
@@ -14,6 +14,10 @@ router.patch("/reject-user/:id", authorizeRole("Admin"), async (req , res) =>{
     adminController.reject_user(req,res)
 })
 
+router.patch("/pending-user/:id", authorizeRole("Admin"), async (req , res) =>{
+    adminController.pending_user(req, res)
+})
+
 router.delete("/delete-user/:id", authorizeRole("Admin"), async (req , res) =>{
     adminController.delete_user(req, res)
 })

--- a/service/adminService.ts
+++ b/service/adminService.ts
@@ -37,4 +37,9 @@ export class AdminService{
      async list_filtering_user(status: VerifiedStatus){
          return await this.adminRepository.list_filtering_user(status)
      }
+
+    async pending_user(user_id: number){
+         return await this.adminRepository.pending_user(user_id)
+    }
+
 }


### PR DESCRIPTION

##  Description
`http://localhost:8000/api/admin/pending-user/:id`
<img width="1034" height="474" alt="Screenshot 2568-11-07 at 22 28 38" src="https://github.com/user-attachments/assets/dbd5c178-e891-4ddf-a8f7-08c9eeadcd13" />
- Admin can now change the user status to pending.

## Related Issue

## Type of Change
-  Bug fix (non-breaking change that fixes an issue)
- New feature (non-breaking change that adds functionality)
## Changes Made
- Fix bugs cannot change user status to pending.